### PR TITLE
Changed TestHelper to read the Api Key from Environment variable

### DIFF
--- a/Orchestrate.Net.Tests/Helpers/TestHelper.cs
+++ b/Orchestrate.Net.Tests/Helpers/TestHelper.cs
@@ -1,4 +1,5 @@
-﻿using System.Configuration;
+﻿using System;
+using System.Configuration;
 
 namespace Orchestrate.Net.Tests.Helpers
 {
@@ -9,8 +10,14 @@ namespace Orchestrate.Net.Tests.Helpers
 		{
 			get
 			{
-				return _apiKey ?? (_apiKey = ConfigurationManager.AppSettings["Orchestrate:ApiKey"]);
+				return _apiKey ?? 
+					(
+						_apiKey = Environment.GetEnvironmentVariable("OrchestrateApiKey") ?? 
+											ConfigurationManager.AppSettings["Orchestrate:ApiKey"]
+					);
 			}
 		}
+
+		
 	}
 }

--- a/README.md
+++ b/README.md
@@ -62,4 +62,9 @@ Are all supported, see the docs on the Orchestrate.io website for details.
 
 #### Building the source
 
-For running tests, be sure to update the `app.config` file in the path `Orchestrate.Net.Tests/` and replace **YOUR-API-KEY-GOES-HERE** with your api key.
+For running tests follow either of the approaches
+  - update the `app.config` file in the path `Orchestrate.Net.Tests/` and replace **YOUR-API-KEY-GOES-HERE** with your api key (remember to unset this value before you commit/push your code to repository).
+                                                                                                          
+  - set the environment variable `OrchestrateApiKey` value to match your api key (if you set this after you have opened Visual Studio, please restart Visual Studio, otherwise the environment variable will not be available).
+
+  If both the above settings are set, then the value set in environment variable will be used.


### PR DESCRIPTION
TestHelper now checks environment variable `OrchestrateApiKey` to get the api key and if not found then uses the `appSettings`.
If both are specified, environment variable takes precedence (should it be other way around?).
