### PR TITLE
Converted Orchestrate.Net to Portable Library

### DIFF
--- a/Orchestrate.Net.Tests/KeyValueTests.cs
+++ b/Orchestrate.Net.Tests/KeyValueTests.cs
@@ -55,10 +55,11 @@ namespace Orchestrate.Net.Tests
             try
             {
                 _orchestrate.Get(CollectionName, "9999");
-            }
+						}
             catch (Exception ex)
             {
-                Assert.IsTrue(ex.Message.Contains("404"));
+							//TODO: (CV) Should change this to rely on the result rather than exception.
+                Assert.IsTrue(ex.ToString().Contains("404"));
             }
         }
 
@@ -384,7 +385,8 @@ namespace Orchestrate.Net.Tests
             }
             catch (Exception ex)
             {
-                Assert.IsTrue(ex.Message.Contains("404"));
+							//TODO: (CV) Should change this to rely on the result rather than exception.
+                Assert.IsTrue(ex.ToString().Contains("404"));
             }
         }
 

--- a/Orchestrate.Net.Tests/Orchestrate.Net.Tests.csproj
+++ b/Orchestrate.Net.Tests/Orchestrate.Net.Tests.csproj
@@ -32,6 +32,13 @@
     <ConsolePause>false</ConsolePause>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Microsoft.Threading.Tasks, Version=1.0.12.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\Microsoft.Bcl.Async.1.0.165\lib\net45\Microsoft.Threading.Tasks.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Threading.Tasks.Extensions">
+      <HintPath>..\packages\Microsoft.Bcl.Async.1.0.165\lib\net45\Microsoft.Threading.Tasks.Extensions.dll</HintPath>
+    </Reference>
     <Reference Include="Newtonsoft.Json">
       <HintPath>..\packages\Newtonsoft.Json.6.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
@@ -40,6 +47,15 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
+    <Reference Include="System.Net" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Net.Http.Extensions">
+      <HintPath>..\packages\Microsoft.Net.Http.2.2.18\lib\net45\System.Net.Http.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Net.Http.Primitives">
+      <HintPath>..\packages\Microsoft.Net.Http.2.2.18\lib\net45\System.Net.Http.Primitives.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Net.Http.WebRequest" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="CollectionTests.cs" />
@@ -64,4 +80,9 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
+  <Import Project="..\packages\Microsoft.Bcl.Build.1.0.10\tools\Microsoft.Bcl.Build.targets" Condition="Exists('..\packages\Microsoft.Bcl.Build.1.0.10\tools\Microsoft.Bcl.Build.targets')" />
+  <Target Name="EnsureBclBuildImported" BeforeTargets="BeforeBuild" Condition="'$(BclBuildImported)' == ''">
+    <Error Condition="!Exists('..\packages\Microsoft.Bcl.Build.1.0.10\tools\Microsoft.Bcl.Build.targets')" Text="This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=317567." HelpKeyword="BCLBUILD2001" />
+    <Error Condition="Exists('..\packages\Microsoft.Bcl.Build.1.0.10\tools\Microsoft.Bcl.Build.targets')" Text="The build restored NuGet packages. Build the project again to include these packages in the build. For more information, see http://go.microsoft.com/fwlink/?LinkID=317568." HelpKeyword="BCLBUILD2002" />
+  </Target>
 </Project>

--- a/Orchestrate.Net.Tests/app.config
+++ b/Orchestrate.Net.Tests/app.config
@@ -1,6 +1,14 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <appSettings>
-    <add key="Orchestrate:ApiKey" value="YOUR-API-KEY-GOES-HERE"/>
+    <add key="Orchestrate:ApiKey" value="YOUR-API-KEY-GOES-HERE" />
   </appSettings>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Net.Http.Primitives" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.2.18.0" newVersion="4.2.18.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
 </configuration>

--- a/Orchestrate.Net.Tests/packages.config
+++ b/Orchestrate.Net.Tests/packages.config
@@ -1,5 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Microsoft.Bcl" version="1.1.3" targetFramework="net45" />
+  <package id="Microsoft.Bcl.Async" version="1.0.165" targetFramework="net45" />
+  <package id="Microsoft.Bcl.Build" version="1.0.10" targetFramework="net45" />
+  <package id="Microsoft.Net.Http" version="2.2.18" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="6.0.1" targetFramework="net45" />
   <package id="NUnit" version="2.6.3" targetFramework="net45" />
 </packages>

--- a/Orchestrate.Net/Extensions/HttpMethodExtensions.cs
+++ b/Orchestrate.Net/Extensions/HttpMethodExtensions.cs
@@ -1,0 +1,21 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+
+namespace Orchestrate.Net
+{
+	internal static class HttpMethodExtensions
+	{
+		private static readonly IEnumerable<HttpMethod> NoBodyHttpMethods = new[]
+		{
+			//Not sure if this is the full list. Need to confirm with RFC.
+			HttpMethod.Get,
+			HttpMethod.Head
+		};
+
+		public static bool CanHaveContent(this HttpMethod httpMethod)
+		{
+			return NoBodyHttpMethods.All(a => a != httpMethod);
+		}
+	}
+}

--- a/Orchestrate.Net/Extensions/StringExtensions.cs
+++ b/Orchestrate.Net/Extensions/StringExtensions.cs
@@ -1,0 +1,27 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+
+namespace Orchestrate.Net
+{
+	public static class StringExtensions
+	{
+		private static readonly IDictionary<string, HttpMethod> HttpMethodsMap = new Dictionary<string, HttpMethod>
+		{
+			{"GET",  HttpMethod.Get},
+			{"DELETE",  HttpMethod.Delete},
+			{"HEAD",  HttpMethod.Head},
+			{"OPTIONS",  HttpMethod.Options},
+			{"POST",  HttpMethod.Post},
+			{"PUT",  HttpMethod.Put},
+			{"TRACE",  HttpMethod.Trace}
+		};
+
+		//TODO: (CV) This extension is temporary (to use System.Net.Http). Once Orchestarte class is rafactored this should go away.
+		internal static HttpMethod ToHttpMethod(this string source)
+		{
+			var needle = source.ToUpper();
+			return HttpMethodsMap.ContainsKey(needle) ? HttpMethodsMap.FirstOrDefault(a => a.Key == needle).Value : null;
+		}
+	}
+}

--- a/Orchestrate.Net/Orchestrate.Net.csproj
+++ b/Orchestrate.Net/Orchestrate.Net.csproj
@@ -9,12 +9,15 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Orchestrate.Net</RootNamespace>
     <AssemblyName>Orchestrate.Net</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProductVersion>12.0.0</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <TargetFrameworkProfile>Profile136</TargetFrameworkProfile>
+    <MinimumVisualStudioVersion>10.0</MinimumVisualStudioVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -34,15 +37,40 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Microsoft.Threading.Tasks">
+      <HintPath>..\packages\Microsoft.Bcl.Async.1.0.165\lib\portable-net40+sl4+win8+wp71\Microsoft.Threading.Tasks.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Threading.Tasks.Extensions">
+      <HintPath>..\packages\Microsoft.Bcl.Async.1.0.165\lib\portable-net40+sl4+win8+wp71\Microsoft.Threading.Tasks.Extensions.dll</HintPath>
+    </Reference>
     <Reference Include="Newtonsoft.Json">
-      <HintPath>..\packages\Newtonsoft.Json.6.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\packages\Newtonsoft.Json.6.0.1\lib\portable-net40+sl5+wp80+win8+monotouch+monoandroid\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.IO">
+      <HintPath>..\packages\Microsoft.Bcl.1.1.3\lib\portable-net40+sl5+win8+wp8\System.IO.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Net.Http">
+      <HintPath>..\packages\Microsoft.Net.Http.2.2.18\lib\portable-net40+sl4+win8+wp71\System.Net.Http.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Net.Http.Extensions">
+      <HintPath>..\packages\Microsoft.Net.Http.2.2.18\lib\portable-net40+sl4+win8+wp71\System.Net.Http.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Net.Http.Primitives">
+      <HintPath>..\packages\Microsoft.Net.Http.2.2.18\lib\portable-net40+sl4+win8+wp71\System.Net.Http.Primitives.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Runtime">
+      <HintPath>..\packages\Microsoft.Bcl.1.1.3\lib\portable-net40+sl5+win8+wp8\System.Runtime.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Threading.Tasks">
+      <HintPath>..\packages\Microsoft.Bcl.1.1.3\lib\portable-net40+sl5+win8+wp8\System.Threading.Tasks.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Communication.cs" />
+    <Compile Include="Extensions\HttpMethodExtensions.cs" />
+    <Compile Include="Extensions\StringExtensions.cs" />
     <Compile Include="IOrchestrate.cs" />
     <Compile Include="Models\BaseResult.cs" />
     <Compile Include="Models\EventMessage.cs" />
@@ -56,11 +84,16 @@
     <Compile Include="Models\SearchResult.cs" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="packages.config" />
   </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
-
+  <Import Project="..\packages\Microsoft.Bcl.Build.1.0.10\tools\Microsoft.Bcl.Build.targets" Condition="Exists('..\packages\Microsoft.Bcl.Build.1.0.10\tools\Microsoft.Bcl.Build.targets')" />
+  <Target Name="EnsureBclBuildImported" BeforeTargets="BeforeBuild" Condition="'$(BclBuildImported)' == ''">
+    <Error Condition="!Exists('..\packages\Microsoft.Bcl.Build.1.0.10\tools\Microsoft.Bcl.Build.targets')" Text="This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=317567." HelpKeyword="BCLBUILD2001" />
+    <Error Condition="Exists('..\packages\Microsoft.Bcl.Build.1.0.10\tools\Microsoft.Bcl.Build.targets')" Text="The build restored NuGet packages. Build the project again to include these packages in the build. For more information, see http://go.microsoft.com/fwlink/?LinkID=317568." HelpKeyword="BCLBUILD2002" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Orchestrate.Net/Orchestrate.cs
+++ b/Orchestrate.Net/Orchestrate.cs
@@ -272,7 +272,7 @@ namespace Orchestrate.Net
                 throw new ArgumentNullException("collectionName", "collectionName cannot be null or empty");
 
             if (limit < 1 || limit > 100)
-                throw new ArgumentOutOfRangeException("limit", limit, "limit must be between 1 and 100");
+                throw new ArgumentOutOfRangeException("limit", "limit must be between 1 and 100");
 
             if (!string.IsNullOrEmpty(startKey) && !string.IsNullOrEmpty(afterKey))
                 throw new ArgumentException("May only specify either a startKey or an afterKey", "startKey");
@@ -330,10 +330,10 @@ namespace Orchestrate.Net
                 throw new ArgumentNullException("query", "query cannot be null or empty");
 
             if (limit < 1 || limit > 100)
-                throw new ArgumentOutOfRangeException("limit", limit, "limit must be between 1 and 100");
+                throw new ArgumentOutOfRangeException("limit", "limit must be between 1 and 100");
 
             if (offset < 0)
-                throw new ArgumentOutOfRangeException("offset", offset, "offset must be at least 0");
+                throw new ArgumentOutOfRangeException("offset", "offset must be at least 0");
 
             var url = UrlBase + collectionName + "?query=" + query + "&limit=" + limit + "&offset=" + offset;
 
@@ -776,7 +776,7 @@ namespace Orchestrate.Net
                 throw new ArgumentNullException("collectionName", "collectionName cannot be null or empty");
 
             if (limit < 1 || limit > 100)
-                throw new ArgumentOutOfRangeException("limit", limit, "limit must be between 1 and 100");
+                throw new ArgumentOutOfRangeException("limit", "limit must be between 1 and 100");
 
             if (!string.IsNullOrEmpty(startKey) && !string.IsNullOrEmpty(afterKey))
                 throw new ArgumentException("May only specify either a startKey or an afterKey", "startKey");
@@ -803,10 +803,10 @@ namespace Orchestrate.Net
                 throw new ArgumentNullException("query", "query cannot be null or empty");
 
             if (limit < 1 || limit > 100)
-                throw new ArgumentOutOfRangeException("limit", limit, "limit must be between 1 and 100");
+                throw new ArgumentOutOfRangeException("limit", "limit must be between 1 and 100");
 
             if (offset < 0)
-                throw new ArgumentOutOfRangeException("offset", offset, "offset must be at least 0");
+                throw new ArgumentOutOfRangeException("offset", "offset must be at least 0");
 
             var url = UrlBase + collectionName + "?query=" + query + "&limit=" + limit + "&offset=" + offset;
             var result = await Communication.CallWebRequestAsync(_apiKey, url, "GET", null);

--- a/Orchestrate.Net/Properties/AssemblyInfo.cs
+++ b/Orchestrate.Net/Properties/AssemblyInfo.cs
@@ -14,14 +14,6 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
-// COM, set the ComVisible attribute to true on that type.
-[assembly: ComVisible(false)]
-
-// The following GUID is for the ID of the typelib if this project is exposed to COM
-[assembly: Guid("0e0a907a-a517-4c8d-ae14-d96a5f7e0355")]
-
 // Version information for an assembly consists of the following four values:
 //
 //      Major Version

--- a/Orchestrate.Net/app.config
+++ b/Orchestrate.Net/app.config
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.6.3.0" newVersion="2.6.3.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Threading.Tasks" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.6.3.0" newVersion="2.6.3.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/Orchestrate.Net/packages.config
+++ b/Orchestrate.Net/packages.config
@@ -1,4 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="6.0.1" targetFramework="net45" />
+  <package id="Microsoft.Bcl" version="1.1.3" targetFramework="portable-win+net40+sl50+wp80" />
+  <package id="Microsoft.Bcl.Async" version="1.0.165" targetFramework="portable-win+net40+sl50+wp80" />
+  <package id="Microsoft.Bcl.Build" version="1.0.10" targetFramework="portable-win+net40+sl50+wp80" />
+  <package id="Microsoft.Net.Http" version="2.2.18" targetFramework="portable-win+net40+sl50+wp80" />
+  <package id="Newtonsoft.Json" version="6.0.1" targetFramework="portable-win+net40+sl50+wp80" />
 </packages>


### PR DESCRIPTION
Made the following changes:
- Changed the Orchestrate.Net project to a Portable library
- Replaced the WebRequest usage with Microsoft Http library (for portability)

No major changes to the existing functionality of the client though.
