### PR TITLE
PutEvent/PutEventAsync support for objects/json strings

### DIFF
--- a/Orchestrate.Net.Tests/EventTests.cs
+++ b/Orchestrate.Net.Tests/EventTests.cs
@@ -6,48 +6,48 @@ using Orchestrate.Net.Tests.Helpers;
 
 namespace Orchestrate.Net.Tests
 {
-	[TestFixture]
-	public class EventTests
-	{
-		private const string CollectionName = "EventTestCollection";
-		private Orchestrate _orchestrate;
+    [TestFixture]
+    public class EventTests
+    {
+        private const string CollectionName = "EventTestCollection";
+        private Orchestrate _orchestrate;
 
-		[TestFixtureSetUp]
-		public static void ClassInitialize()
-		{
-			var orchestrate = new Orchestrate(TestHelper.ApiKey);
-			var item = new TestData { Id = 1, Value = "Inital Test Item" };
+        [TestFixtureSetUp]
+        public static void ClassInitialize()
+        {
+            var orchestrate = new Orchestrate(TestHelper.ApiKey);
+            var item = new TestData { Id = 1, Value = "Inital Test Item" };
 
-			orchestrate.CreateCollection(CollectionName, "1", item);
-		}
+            orchestrate.CreateCollection(CollectionName, "1", item);
+        }
 
-		[TestFixtureTearDown]
-		public static void ClassCleanUp()
-		{
-			var orchestrate = new Orchestrate(TestHelper.ApiKey);
-			orchestrate.DeleteCollection(CollectionName);
-		}
+        [TestFixtureTearDown]
+        public static void ClassCleanUp()
+        {
+            var orchestrate = new Orchestrate(TestHelper.ApiKey);
+            orchestrate.DeleteCollection(CollectionName);
+        }
 
-		[SetUp]
-		public void TestInitialize()
-		{
-			_orchestrate = new Orchestrate(TestHelper.ApiKey);
-		}
+        [SetUp]
+        public void TestInitialize()
+        {
+            _orchestrate = new Orchestrate(TestHelper.ApiKey);
+        }
 
-		[TearDown]
-		public void TestCleanup()
-		{
-			// nothing to see here...
-		}
+        [TearDown]
+        public void TestCleanup()
+        {
+            // nothing to see here...
+        }
 
-		[Test]
-		public void PutEventNowTimeStampAsObject()
-		{
+        [Test]
+        public void PutEventNowTimeStampAsObject()
+        {
             var item = new TestData { Id = 3, Value = "A successful object PUT" };
             var result = _orchestrate.PutEvent(CollectionName, "1", "comment", DateTime.UtcNow, item);
 
-			Assert.IsTrue(result.Value == null || result.Value.ToString() == string.Empty);
-		}
+            Assert.IsTrue(result.Value == null || result.Value.ToString() == string.Empty);
+        }
 
         [Test]
         public void PutEventNowTimeStampAsString()
@@ -79,13 +79,13 @@ namespace Orchestrate.Net.Tests
         }
 
         [Test]
-		public void PutEventNoTimeStamp()
-		{
+        public void PutEventNoTimeStamp()
+        {
             var item = new TestData { Id = 3, Value = "A successful object PUT" };
             var result = _orchestrate.PutEvent(CollectionName, "1", "comment", null, item);
 
-			Assert.IsTrue(result.Value == null || result.Value.ToString() == string.Empty);
-		}
+            Assert.IsTrue(result.Value == null || result.Value.ToString() == string.Empty);
+        }
 
         [Test]
         public void PutEventNoTimeStampAsync()
@@ -97,21 +97,21 @@ namespace Orchestrate.Net.Tests
         }
 
         [Test]
-		public void PutEventWithNoCollectionName()
-		{
-			try
-			{
+        public void PutEventWithNoCollectionName()
+        {
+            try
+            {
                 var item = new TestData { Id = 3, Value = "A successful object PUT" };
-				_orchestrate.PutEvent(string.Empty, "1", "comment", null, item);
-			}
-			catch (ArgumentNullException ex)
-			{
-				Assert.IsTrue(ex.ParamName == "collectionName");
-				return;
-			}
+                _orchestrate.PutEvent(string.Empty, "1", "comment", null, item);
+            }
+            catch (ArgumentNullException ex)
+            {
+                Assert.IsTrue(ex.ParamName == "collectionName");
+                return;
+            }
 
-			Assert.Fail("No Exception Thrown");
-		}
+            Assert.Fail("No Exception Thrown");
+        }
 
         [Test]
         public void PutEventWithNoCollectionNameAsync()
@@ -132,21 +132,21 @@ namespace Orchestrate.Net.Tests
         }
 
         [Test]
-		public void PutEventWithNoKey()
-		{
-			try
-			{
+        public void PutEventWithNoKey()
+        {
+            try
+            {
                 var item = new TestData { Id = 3, Value = "A successful object PUT" };
-				_orchestrate.PutEvent(CollectionName, string.Empty, "comment", null, item);
-			}
-			catch (ArgumentNullException ex)
-			{
-				Assert.IsTrue(ex.ParamName == "key");
-				return;
-			}
+                _orchestrate.PutEvent(CollectionName, string.Empty, "comment", null, item);
+            }
+            catch (ArgumentNullException ex)
+            {
+                Assert.IsTrue(ex.ParamName == "key");
+                return;
+            }
 
-			Assert.Fail("No Exception Thrown");
-		}
+            Assert.Fail("No Exception Thrown");
+        }
 
         [Test]
         public void PutEventWithNoKeyAsync()
@@ -167,21 +167,21 @@ namespace Orchestrate.Net.Tests
         }
 
         [Test]
-		public void PutEventWithNoType()
-		{
-			try
-			{
+        public void PutEventWithNoType()
+        {
+            try
+            {
                 var item = new TestData { Id = 3, Value = "A successful object PUT" };
-				_orchestrate.PutEvent(CollectionName, "1", string.Empty, null, item);
-			}
-			catch (ArgumentNullException ex)
-			{
-				Assert.IsTrue(ex.ParamName == "type");
-				return;
-			}
+                _orchestrate.PutEvent(CollectionName, "1", string.Empty, null, item);
+            }
+            catch (ArgumentNullException ex)
+            {
+                Assert.IsTrue(ex.ParamName == "type");
+                return;
+            }
 
-			Assert.Fail("No Exception Thrown");
-		}
+            Assert.Fail("No Exception Thrown");
+        }
 
         [Test]
         public void PutEventWithNoTypeAsync()
@@ -202,14 +202,14 @@ namespace Orchestrate.Net.Tests
         }
 
         [Test]
-		public void GetEventsNoStartEnd()
-		{
+        public void GetEventsNoStartEnd()
+        {
             var item = new TestData { Id = 3, Value = "A successful object PUT" };
-			_orchestrate.PutEvent(CollectionName, "1", "comment", DateTime.UtcNow, item);
-			var result = _orchestrate.GetEvents(CollectionName, "1", "comment");
+            _orchestrate.PutEvent(CollectionName, "1", "comment", DateTime.UtcNow, item);
+            var result = _orchestrate.GetEvents(CollectionName, "1", "comment");
 
-			Assert.IsTrue(result.Count > 0);
-		}
+            Assert.IsTrue(result.Count > 0);
+        }
 
         [Test]
         public void GetEventsNoStartEndAsync()
@@ -222,14 +222,14 @@ namespace Orchestrate.Net.Tests
         }
 
         [Test]
-		public void GetEventsWithStartDate()
-		{
+        public void GetEventsWithStartDate()
+        {
             var item = new TestData { Id = 3, Value = "A successful object PUT" };
-			_orchestrate.PutEvent(CollectionName, "1", "comment", DateTime.UtcNow, item);
-			var result = _orchestrate.GetEvents(CollectionName, "1", "comment", DateTime.UtcNow.AddHours(-1));
+            _orchestrate.PutEvent(CollectionName, "1", "comment", DateTime.UtcNow, item);
+            var result = _orchestrate.GetEvents(CollectionName, "1", "comment", DateTime.UtcNow.AddHours(-1));
 
-			Assert.IsTrue(result.Count > 0);
-		}
+            Assert.IsTrue(result.Count > 0);
+        }
 
         [Test]
         public void GetEventsWithStartDateAsync()
@@ -242,14 +242,14 @@ namespace Orchestrate.Net.Tests
         }
 
         [Test]
-		public void GetEventsWithEndDate()
-		{
+        public void GetEventsWithEndDate()
+        {
             var item = new TestData { Id = 3, Value = "A successful object PUT" };
-			_orchestrate.PutEvent(CollectionName, "1", "comment", DateTime.UtcNow, item);
-			var result = _orchestrate.GetEvents(CollectionName, "1", "comment", null, DateTime.UtcNow.AddHours(1));
+            _orchestrate.PutEvent(CollectionName, "1", "comment", DateTime.UtcNow, item);
+            var result = _orchestrate.GetEvents(CollectionName, "1", "comment", null, DateTime.UtcNow.AddHours(1));
 
-			Assert.IsTrue(result.Count > 0);
-		}
+            Assert.IsTrue(result.Count > 0);
+        }
 
         [Test]
         public void GetEventsWithEndDateAsync()
@@ -262,14 +262,14 @@ namespace Orchestrate.Net.Tests
         }
 
         [Test]
-		public void GetEventsWithStartAndEndDate()
-		{
+        public void GetEventsWithStartAndEndDate()
+        {
             var item = new TestData { Id = 3, Value = "A successful object PUT" };
-			_orchestrate.PutEvent(CollectionName, "1", "comment", DateTime.UtcNow, item);
-			var result = _orchestrate.GetEvents(CollectionName, "1", "comment", DateTime.UtcNow.AddHours(-1), DateTime.UtcNow.AddHours(1));
+            _orchestrate.PutEvent(CollectionName, "1", "comment", DateTime.UtcNow, item);
+            var result = _orchestrate.GetEvents(CollectionName, "1", "comment", DateTime.UtcNow.AddHours(-1), DateTime.UtcNow.AddHours(1));
 
-			Assert.IsTrue(result.Count > 0);
-		}
+            Assert.IsTrue(result.Count > 0);
+        }
 
         [Test]
         public void GetEventsWithStartAndEndDateAsync()
@@ -282,20 +282,20 @@ namespace Orchestrate.Net.Tests
         }
 
         [Test]
-		public void GetEventsWithNoCollectionName()
-		{
-			try
-			{
-				_orchestrate.GetEvents(string.Empty, "1", "comment");
-			}
-			catch (ArgumentNullException ex)
-			{
-				Assert.IsTrue(ex.ParamName == "collectionName");
-				return;
-			}
+        public void GetEventsWithNoCollectionName()
+        {
+            try
+            {
+                _orchestrate.GetEvents(string.Empty, "1", "comment");
+            }
+            catch (ArgumentNullException ex)
+            {
+                Assert.IsTrue(ex.ParamName == "collectionName");
+                return;
+            }
 
-			Assert.Fail("No Exception Thrown");
-		}
+            Assert.Fail("No Exception Thrown");
+        }
 
         [Test]
         public void GetEventsWithNoCollectionNameAsync()
@@ -315,20 +315,20 @@ namespace Orchestrate.Net.Tests
         }
 
         [Test]
-		public void GetEventsWithNoKey()
-		{
-			try
-			{
-				_orchestrate.GetEvents(CollectionName, string.Empty, "comment");
-			}
-			catch (ArgumentNullException ex)
-			{
-				Assert.IsTrue(ex.ParamName == "key");
-				return;
-			}
+        public void GetEventsWithNoKey()
+        {
+            try
+            {
+                _orchestrate.GetEvents(CollectionName, string.Empty, "comment");
+            }
+            catch (ArgumentNullException ex)
+            {
+                Assert.IsTrue(ex.ParamName == "key");
+                return;
+            }
 
-			Assert.Fail("No Exception Thrown");
-		}
+            Assert.Fail("No Exception Thrown");
+        }
 
         [Test]
         public void GetEventsWithNoKeyAsync()
@@ -348,20 +348,20 @@ namespace Orchestrate.Net.Tests
         }
 
         [Test]
-		public void GetEventsWithNoType()
-		{
-			try
-			{
-				_orchestrate.GetEvents(CollectionName, "1", string.Empty);
-			}
-			catch (ArgumentNullException ex)
-			{
-				Assert.IsTrue(ex.ParamName == "type");
-				return;
-			}
+        public void GetEventsWithNoType()
+        {
+            try
+            {
+                _orchestrate.GetEvents(CollectionName, "1", string.Empty);
+            }
+            catch (ArgumentNullException ex)
+            {
+                Assert.IsTrue(ex.ParamName == "type");
+                return;
+            }
 
-			Assert.Fail("No Exception Thrown");
-		}
+            Assert.Fail("No Exception Thrown");
+        }
 
         [Test]
         public void GetEventsWithNoTypeAsync()

--- a/Orchestrate.Net.Tests/EventTests.cs
+++ b/Orchestrate.Net.Tests/EventTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Linq;
 using NUnit.Framework;
+using Newtonsoft.Json;
 using Orchestrate.Net.Tests.Helpers;
 
 namespace Orchestrate.Net.Tests
@@ -40,17 +41,39 @@ namespace Orchestrate.Net.Tests
 		}
 
 		[Test]
-		public void PutEventNowTimeStamp()
+		public void PutEventNowTimeStampAsObject()
 		{
-			var result = _orchestrate.PutEvent(CollectionName, "1", "comment", DateTime.UtcNow, "This is the PutEventNowTimeStamp comment.");
+            var item = new TestData { Id = 3, Value = "A successful object PUT" };
+            var result = _orchestrate.PutEvent(CollectionName, "1", "comment", DateTime.UtcNow, item);
 
 			Assert.IsTrue(result.Value == null || result.Value.ToString() == string.Empty);
 		}
 
         [Test]
-        public void PutEventNowTimeStampAsync()
+        public void PutEventNowTimeStampAsString()
         {
-            var result = _orchestrate.PutEventAsync(CollectionName, "1", "comment", DateTime.UtcNow, "This is the PutEventNowTimeStamp comment.").Result;
+            var item = new TestData { Id = 3, Value = "A successful object PUT" };
+            var str = JsonConvert.SerializeObject(item);
+            var result = _orchestrate.PutEvent(CollectionName, "1", "comment", DateTime.UtcNow, str);
+
+            Assert.IsTrue(result.Value == null || result.Value.ToString() == string.Empty);
+        }
+
+        [Test]
+        public void PutEventNowTimeStampAsyncAsObject()
+        {
+            var item = new TestData { Id = 3, Value = "A successful object PUT" };
+            var result = _orchestrate.PutEventAsync(CollectionName, "1", "comment", DateTime.UtcNow, item).Result;
+
+            Assert.IsTrue(result.Value == null || result.Value.ToString() == string.Empty);
+        }
+
+        [Test]
+        public void PutEventNowTimeStampAsyncAsString()
+        {
+            var item = new TestData { Id = 3, Value = "A successful object PUT" };
+            var str = JsonConvert.SerializeObject(item);
+            var result = _orchestrate.PutEventAsync(CollectionName, "1", "comment", DateTime.UtcNow, str).Result;
 
             Assert.IsTrue(result.Value == null || result.Value.ToString() == string.Empty);
         }
@@ -58,7 +81,8 @@ namespace Orchestrate.Net.Tests
         [Test]
 		public void PutEventNoTimeStamp()
 		{
-			var result = _orchestrate.PutEvent(CollectionName, "1", "comment", null, "This is the PutEventNoTimeStamp comment.");
+            var item = new TestData { Id = 3, Value = "A successful object PUT" };
+            var result = _orchestrate.PutEvent(CollectionName, "1", "comment", null, item);
 
 			Assert.IsTrue(result.Value == null || result.Value.ToString() == string.Empty);
 		}
@@ -66,7 +90,8 @@ namespace Orchestrate.Net.Tests
         [Test]
         public void PutEventNoTimeStampAsync()
         {
-            var result = _orchestrate.PutEventAsync(CollectionName, "1", "comment", null, "This is the PutEventNoTimeStamp comment.").Result;
+            var item = new TestData { Id = 3, Value = "A successful object PUT" };
+            var result = _orchestrate.PutEventAsync(CollectionName, "1", "comment", null, item).Result;
 
             Assert.IsTrue(result.Value == null || result.Value.ToString() == string.Empty);
         }
@@ -76,7 +101,8 @@ namespace Orchestrate.Net.Tests
 		{
 			try
 			{
-				_orchestrate.PutEvent(string.Empty, "1", "comment", null, "This is the PutEventWithNoCollectionName comment.");
+                var item = new TestData { Id = 3, Value = "A successful object PUT" };
+				_orchestrate.PutEvent(string.Empty, "1", "comment", null, item);
 			}
 			catch (ArgumentNullException ex)
 			{
@@ -92,7 +118,8 @@ namespace Orchestrate.Net.Tests
         {
             try
             {
-                var result = _orchestrate.PutEventAsync(string.Empty, "1", "comment", null, "This is the PutEventWithNoCollectionName comment.").Result;
+                var item = new TestData { Id = 3, Value = "A successful object PUT" };
+                var result = _orchestrate.PutEventAsync(string.Empty, "1", "comment", null, item).Result;
             }
             catch (AggregateException ex)
             {
@@ -109,7 +136,8 @@ namespace Orchestrate.Net.Tests
 		{
 			try
 			{
-				_orchestrate.PutEvent(CollectionName, string.Empty, "comment", null, "This is the PutEventWithNoKey comment.");
+                var item = new TestData { Id = 3, Value = "A successful object PUT" };
+				_orchestrate.PutEvent(CollectionName, string.Empty, "comment", null, item);
 			}
 			catch (ArgumentNullException ex)
 			{
@@ -125,7 +153,8 @@ namespace Orchestrate.Net.Tests
         {
             try
             {
-                var result = _orchestrate.PutEventAsync(CollectionName, string.Empty, "comment", null, "This is the PutEventWithNoKey comment.").Result;
+                var item = new TestData { Id = 3, Value = "A successful object PUT" };
+                var result = _orchestrate.PutEventAsync(CollectionName, string.Empty, "comment", null, item).Result;
             }
             catch (AggregateException ex)
             {
@@ -142,7 +171,8 @@ namespace Orchestrate.Net.Tests
 		{
 			try
 			{
-				_orchestrate.PutEvent(CollectionName, "1", string.Empty, null, "This is the PutEventWithNoType comment.");
+                var item = new TestData { Id = 3, Value = "A successful object PUT" };
+				_orchestrate.PutEvent(CollectionName, "1", string.Empty, null, item);
 			}
 			catch (ArgumentNullException ex)
 			{
@@ -158,7 +188,8 @@ namespace Orchestrate.Net.Tests
         {
             try
             {
-                var result = _orchestrate.PutEventAsync(CollectionName, "1", string.Empty, null, "This is the PutEventWithNoType comment.").Result;
+                var item = new TestData { Id = 3, Value = "A successful object PUT" };
+                var result = _orchestrate.PutEventAsync(CollectionName, "1", string.Empty, null, item).Result;
             }
             catch (AggregateException ex)
             {
@@ -173,7 +204,8 @@ namespace Orchestrate.Net.Tests
         [Test]
 		public void GetEventsNoStartEnd()
 		{
-			_orchestrate.PutEvent(CollectionName, "1", "comment", DateTime.UtcNow, "This is the GetEventsNoStartEnd comment.");
+            var item = new TestData { Id = 3, Value = "A successful object PUT" };
+			_orchestrate.PutEvent(CollectionName, "1", "comment", DateTime.UtcNow, item);
 			var result = _orchestrate.GetEvents(CollectionName, "1", "comment");
 
 			Assert.IsTrue(result.Count > 0);
@@ -182,7 +214,8 @@ namespace Orchestrate.Net.Tests
         [Test]
         public void GetEventsNoStartEndAsync()
         {
-            _orchestrate.PutEvent(CollectionName, "1", "comment", DateTime.UtcNow, "This is the GetEventsNoStartEnd comment.");
+            var item = new TestData { Id = 3, Value = "A successful object PUT" };
+            _orchestrate.PutEvent(CollectionName, "1", "comment", DateTime.UtcNow, item);
             var result = _orchestrate.GetEventsAsync(CollectionName, "1", "comment").Result;
 
             Assert.IsTrue(result.Count > 0);
@@ -191,7 +224,8 @@ namespace Orchestrate.Net.Tests
         [Test]
 		public void GetEventsWithStartDate()
 		{
-			_orchestrate.PutEvent(CollectionName, "1", "comment", DateTime.UtcNow, "This is the GetEventsWithStartDate comment.");
+            var item = new TestData { Id = 3, Value = "A successful object PUT" };
+			_orchestrate.PutEvent(CollectionName, "1", "comment", DateTime.UtcNow, item);
 			var result = _orchestrate.GetEvents(CollectionName, "1", "comment", DateTime.UtcNow.AddHours(-1));
 
 			Assert.IsTrue(result.Count > 0);
@@ -200,7 +234,8 @@ namespace Orchestrate.Net.Tests
         [Test]
         public void GetEventsWithStartDateAsync()
         {
-            _orchestrate.PutEvent(CollectionName, "1", "comment", DateTime.UtcNow, "This is the GetEventsWithStartDate comment.");
+            var item = new TestData { Id = 3, Value = "A successful object PUT" };
+            _orchestrate.PutEvent(CollectionName, "1", "comment", DateTime.UtcNow, item);
             var result = _orchestrate.GetEventsAsync(CollectionName, "1", "comment", DateTime.UtcNow.AddHours(-1)).Result;
 
             Assert.IsTrue(result.Count > 0);
@@ -209,7 +244,8 @@ namespace Orchestrate.Net.Tests
         [Test]
 		public void GetEventsWithEndDate()
 		{
-			_orchestrate.PutEvent(CollectionName, "1", "comment", DateTime.UtcNow, "This is the GetEventsWithEndDate comment.");
+            var item = new TestData { Id = 3, Value = "A successful object PUT" };
+			_orchestrate.PutEvent(CollectionName, "1", "comment", DateTime.UtcNow, item);
 			var result = _orchestrate.GetEvents(CollectionName, "1", "comment", null, DateTime.UtcNow.AddHours(1));
 
 			Assert.IsTrue(result.Count > 0);
@@ -218,7 +254,8 @@ namespace Orchestrate.Net.Tests
         [Test]
         public void GetEventsWithEndDateAsync()
         {
-            _orchestrate.PutEvent(CollectionName, "1", "comment", DateTime.UtcNow, "This is the GetEventsWithEndDate comment.");
+            var item = new TestData { Id = 3, Value = "A successful object PUT" };
+            _orchestrate.PutEvent(CollectionName, "1", "comment", DateTime.UtcNow, item);
             var result = _orchestrate.GetEventsAsync(CollectionName, "1", "comment", null, DateTime.UtcNow.AddHours(1)).Result;
 
             Assert.IsTrue(result.Count > 0);
@@ -227,7 +264,8 @@ namespace Orchestrate.Net.Tests
         [Test]
 		public void GetEventsWithStartAndEndDate()
 		{
-			_orchestrate.PutEvent(CollectionName, "1", "comment", DateTime.UtcNow, "This is the GetEventsWithStartAndEndDate comment.");
+            var item = new TestData { Id = 3, Value = "A successful object PUT" };
+			_orchestrate.PutEvent(CollectionName, "1", "comment", DateTime.UtcNow, item);
 			var result = _orchestrate.GetEvents(CollectionName, "1", "comment", DateTime.UtcNow.AddHours(-1), DateTime.UtcNow.AddHours(1));
 
 			Assert.IsTrue(result.Count > 0);
@@ -236,7 +274,8 @@ namespace Orchestrate.Net.Tests
         [Test]
         public void GetEventsWithStartAndEndDateAsync()
         {
-            _orchestrate.PutEvent(CollectionName, "1", "comment", DateTime.UtcNow, "This is the GetEventsWithStartAndEndDate comment.");
+            var item = new TestData { Id = 3, Value = "A successful object PUT" };
+            _orchestrate.PutEvent(CollectionName, "1", "comment", DateTime.UtcNow, item);
             var result = _orchestrate.GetEventsAsync(CollectionName, "1", "comment", DateTime.UtcNow.AddHours(-1), DateTime.UtcNow.AddHours(1)).Result;
 
             Assert.IsTrue(result.Count > 0);

--- a/Orchestrate.Net/IOrchestrate.cs
+++ b/Orchestrate.Net/IOrchestrate.cs
@@ -25,7 +25,8 @@ namespace Orchestrate.Net
         SearchResult Search(string collectionName, string query, int limit, int offset);
 
         EventResultList GetEvents(string collectionName, string key, string type, DateTime? start, DateTime? end);
-        Result PutEvent(string collectionName, string key, string type, DateTime? timeStamp, string msg);
+        Result PutEvent(string collectionName, string key, string type, DateTime? timeStamp, string item);
+        Result PutEvent(string collectionName, string key, string type, DateTime? timeStamp, object item);
 
         ListResult GetGraph(string collectionName, string key, string[] kinds);
         Result PutGraph(string collectionName, string key, string kind, string toCollectionName, string toKey);
@@ -51,7 +52,8 @@ namespace Orchestrate.Net
         Task<SearchResult> SearchAsync(string collectionName, string query, int limit, int offset);
 
         Task<EventResultList> GetEventsAsync(string collectionName, string key, string type, DateTime? start, DateTime? end);
-        Task<Result> PutEventAsync(string collectionName, string key, string type, DateTime? timeStamp, string msg);
+        Task<Result> PutEventAsync(string collectionName, string key, string type, DateTime? timeStamp, string item);
+        Task<Result> PutEventAsync(string collectionName, string key, string type, DateTime? timeStamp, object item);
 
         Task<ListResult> GetGraphAsync(string collectionName, string key, string[] kinds);
         Task<Result> PutGraphAsync(string collectionName, string key, string kind, string toCollectionName, string toKey);

--- a/Orchestrate.Net/Models/EventMessage.cs
+++ b/Orchestrate.Net/Models/EventMessage.cs
@@ -1,7 +1,0 @@
-﻿namespace Orchestrate.Net
-{
-    internal class EventMessage
-    {
-        public string Msg { get; set; }
-    }
-}

--- a/Orchestrate.Net/Orchestrate.Net.csproj
+++ b/Orchestrate.Net/Orchestrate.Net.csproj
@@ -73,7 +73,6 @@
     <Compile Include="Extensions\StringExtensions.cs" />
     <Compile Include="IOrchestrate.cs" />
     <Compile Include="Models\BaseResult.cs" />
-    <Compile Include="Models\EventMessage.cs" />
     <Compile Include="Models\EventResult.cs" />
     <Compile Include="Models\EventResultList.cs" />
     <Compile Include="Models\ListResult.cs" />

--- a/Orchestrate.Net/Orchestrate.cs
+++ b/Orchestrate.Net/Orchestrate.cs
@@ -364,7 +364,7 @@ namespace Orchestrate.Net
             return JsonConvert.DeserializeObject<EventResultList>(Communication.CallWebRequest(_apiKey, url, "GET", null).Payload);
         }
 
-        public Result PutEvent(string collectionName, string key, string type, DateTime? timeStamp, string msg)
+        public Result PutEvent(string collectionName, string key, string type, DateTime? timeStamp, string item)
         {
             if (string.IsNullOrEmpty(collectionName))
                 throw new ArgumentNullException("collectionName", "collectionName cannot be null or empty");
@@ -380,10 +380,7 @@ namespace Orchestrate.Net
             if (timeStamp != null)
                 url += "?timestamp=" + ConvertToUnixTimestamp(timeStamp.Value);
 
-            var message = new EventMessage { Msg = msg };
-            var json = JsonConvert.SerializeObject(message);
-
-            var baseResult = Communication.CallWebRequest(_apiKey, url, "PUT", json);
+            var baseResult = Communication.CallWebRequest(_apiKey, url, "PUT", item);
 
             return new Result
             {
@@ -396,6 +393,15 @@ namespace Orchestrate.Net
                 Score = 1,
                 Value = baseResult.Payload
             };
+        }
+
+        public Result PutEvent(string collectionName, string key, string type, DateTime? timeStamp, object item)
+        {
+            if (item == null)
+                throw new ArgumentNullException("item", "item cannot be null");
+            var json = JsonConvert.SerializeObject(item);
+
+            return PutEvent(collectionName, key, type, timeStamp, json);
         }
 
         public ListResult GetGraph(string collectionName, string key, string[] kinds)
@@ -840,7 +846,7 @@ namespace Orchestrate.Net
             return JsonConvert.DeserializeObject<EventResultList>(result.Payload);
         }
 
-        public async Task<Result> PutEventAsync(string collectionName, string key, string type, DateTime? timeStamp, string msg)
+        public async Task<Result> PutEventAsync(string collectionName, string key, string type, DateTime? timeStamp, string item)
         {
             if (string.IsNullOrEmpty(collectionName))
                 throw new ArgumentNullException("collectionName", "collectionName cannot be null or empty");
@@ -856,10 +862,7 @@ namespace Orchestrate.Net
             if (timeStamp != null)
                 url += "?timestamp=" + ConvertToUnixTimestamp(timeStamp.Value);
 
-            var message = new EventMessage { Msg = msg };
-            var json = JsonConvert.SerializeObject(message);
-
-            var baseResult = await Communication.CallWebRequestAsync(_apiKey, url, "PUT", json);
+            var baseResult = await Communication.CallWebRequestAsync(_apiKey, url, "PUT", item);
 
             return new Result
             {
@@ -872,6 +875,15 @@ namespace Orchestrate.Net
                 Score = 1,
                 Value = baseResult.Payload
             };
+        }
+
+        public async Task<Result> PutEventAsync(string collectionName, string key, string type, DateTime? timeStamp, object item)
+        {
+            if (item == null)
+                throw new ArgumentNullException("item", "item cannot be null");
+            var json = JsonConvert.SerializeObject(item);
+
+            return await PutEventAsync(collectionName, key, type, timeStamp, json);
         }
 
         public async Task<ListResult> GetGraphAsync(string collectionName, string key, string[] kinds)


### PR DESCRIPTION
I don't know if this Patch is wanted, but there was no possibilty to send a custom object with the PutEvent/PutEventAsync method. (It got stringified into `EventMessage.cs` )

So this PR contains the following two changes:
- PutEvent/PutEventAsync now supports objects (equal to Put/PutAsync)
- `EventTests.cs` contained both, tabs and 4 spaces. Converted to spaces-only

If you want anything changed, just tell me :smiley: 
