### PR TITLE
POST Functionality

### DIFF
--- a/Orchestrate.Net.Tests/KeyValueTests.cs
+++ b/Orchestrate.Net.Tests/KeyValueTests.cs
@@ -154,6 +154,120 @@ namespace Orchestrate.Net.Tests
 
         #endregion
 
+        #region Post Tests
+
+        [Test]
+        public void PostAsObject()
+        {
+            var item = new TestData { Id = 3, Value = "A successful object POST" };
+            var result = _orchestrate.Post(CollectionName, item);
+
+            Assert.IsTrue(result.Path.Ref.Length > 0);
+        }
+
+        [Test]
+        public void PostAsObjectAsync()
+        {
+            var item = new TestData { Id = 3, Value = "A successful object POST" };
+            var result = _orchestrate.PostAsync(CollectionName, item).Result;
+
+            Assert.IsTrue(result.Path.Ref.Length > 0);
+        }
+
+        [Test]
+        public void PostAsString()
+        {
+            var item = new TestData { Id = 4, Value = "A successful string POST" };
+            var json = JsonConvert.SerializeObject(item);
+            var result = _orchestrate.Post(CollectionName, json);
+
+            Assert.IsTrue(result.Path.Ref.Length > 0);
+        }
+
+        [Test]
+        public void PostAsStringAsync()
+        {
+            var item = new TestData { Id = 4, Value = "A successful string POST" };
+            var json = JsonConvert.SerializeObject(item);
+            var result = _orchestrate.PostAsync(CollectionName, json).Result;
+
+            Assert.IsTrue(result.Path.Ref.Length > 0);
+        }
+
+        [Test]
+        public void PostWithNoCollectionName()
+        {
+            var item = new TestData { Id = 5, Value = "An  unsuccessful string POST" };
+            var json = JsonConvert.SerializeObject(item);
+
+            try
+            {
+                _orchestrate.Post(string.Empty, json);
+            }
+            catch (ArgumentNullException ex)
+            {
+                Assert.IsTrue(ex.ParamName == "collectionName");
+                return;
+            }
+
+            Assert.Fail("No Exception Thrown");
+        }
+
+        [Test]
+        public void PostWithNoCollectionNameAsync()
+        {
+            var item = new TestData { Id = 5, Value = "An  unsuccessful string POST" };
+            var json = JsonConvert.SerializeObject(item);
+
+            try
+            {
+                var result = _orchestrate.PostAsync(string.Empty, json).Result;
+            }
+            catch (AggregateException ex)
+            {
+                var inner = ex.InnerExceptions.First() as ArgumentNullException;
+                Assert.IsTrue(inner.ParamName == "collectionName");
+                return;
+            }
+
+            Assert.Fail("No Exception Thrown");
+        }
+
+        [Test]
+        public void PostWithNoItem()
+        {
+            try
+            {
+                _orchestrate.Post(CollectionName, string.Empty);
+            }
+            catch (ArgumentNullException ex)
+            {
+                Assert.IsTrue(ex.ParamName == "item");
+                return;
+            }
+
+            Assert.Fail("No Exception Thrown");
+        }
+
+        [Test]
+        public void PostWithNoItemAsync()
+        {
+            try
+            {
+                var result = _orchestrate.PostAsync(CollectionName, string.Empty).Result;
+            }
+            catch (AggregateException ex)
+            {
+                var inner = ex.InnerExceptions.First() as ArgumentNullException;
+                Assert.IsTrue(inner.ParamName == "item");
+                return;
+            }
+
+            Assert.Fail("No Exception Thrown");
+        }
+
+        #endregion
+
         #region Put Tests
 
         [Test]

--- a/Orchestrate.Net/IOrchestrate.cs
+++ b/Orchestrate.Net/IOrchestrate.cs
@@ -11,6 +11,8 @@ namespace Orchestrate.Net
 
         Result Get(string collectionName, string key);
         Result Get(string collectionName, string key, string reference);
+        Result Post(string collectionName, object item);
+        Result Post(string collectionName, string item);
         Result Put(string collectionName, string key, object item);
         Result Put(string collectionName, string key, string item);
         Result PutIfMatch(string collectionName, string key, object item, string ifMatch);
@@ -37,6 +39,8 @@ namespace Orchestrate.Net
 
         Task<Result> GetAsync(string collectionName, string key);
         Task<Result> GetAsync(string collectionName, string key, string reference);
+        Task<Result> PostAsync(string collectionName, object item);
+        Task<Result> PostAsync(string collectionName, string item);
         Task<Result> PutAsync(string collectionName, string key, object item);
         Task<Result> PutAsync(string collectionName, string key, string item);
         Task<Result> PutIfMatchAsync(string collectionName, string key, object item, string ifMatch);

--- a/Orchestrate.Net/Orchestrate.cs
+++ b/Orchestrate.Net/Orchestrate.cs
@@ -8,11 +8,12 @@ namespace Orchestrate.Net
     public class Orchestrate : IOrchestrate
     {
         private readonly string _apiKey;
-        private const string UrlBase = @"https://api.orchestrate.io/v0/";
+        private string UrlBase = @"https://api.orchestrate.io/";
 
-        public Orchestrate(string apiKey)
+        public Orchestrate(string apiKey, string host="https://api.orchestrate.io/")
         {
             _apiKey = apiKey;
+            UrlBase = host + "v0/";
         }
 
         #region IOrchestrate Sync Members

--- a/Orchestrate.Net/Orchestrate.cs
+++ b/Orchestrate.Net/Orchestrate.cs
@@ -125,6 +125,41 @@ namespace Orchestrate.Net
             };
         }
 
+        public Result Post(string collectionName, string item)
+        {
+            if (string.IsNullOrEmpty(collectionName))
+                throw new ArgumentNullException("collectionName", "collectionName cannot be null or empty");
+
+            if (string.IsNullOrEmpty(item))
+                throw new ArgumentNullException("item", "item cannot be empty");
+
+            var url = UrlBase + collectionName;
+            var baseResult = Communication.CallWebRequest(_apiKey, url, "POST", item);
+
+            var key = baseResult.Location.Remove(0, 15).Remove(16);
+
+            return new Result
+            {
+                Path = new OrchestratePath
+                {
+                    Collection = collectionName,
+                    Key = key,
+                    Ref = baseResult.ETag
+                },
+                Score = 1,
+                Value = baseResult.Payload
+            };
+        }
+
+        public Result Post(string collectionName, object item)
+        {
+            if (item == null)
+                throw new ArgumentNullException("item", "item cannot be null");
+
+            var json = JsonConvert.SerializeObject(item);
+            return Post(collectionName, json);
+        }
+
         public Result Put(string collectionName, string key, string item)
         {
             if (string.IsNullOrEmpty(collectionName))
@@ -582,6 +617,41 @@ namespace Orchestrate.Net
 
             var url = UrlBase + collectionName + "/" + key + "/refs/" + reference;
             var baseResult = await Communication.CallWebRequestAsync(_apiKey, url, "GET", null);
+
+            return new Result
+            {
+                Path = new OrchestratePath
+                {
+                    Collection = collectionName,
+                    Key = key,
+                    Ref = baseResult.ETag
+                },
+                Score = 1,
+                Value = baseResult.Payload
+            };
+        }
+
+        public async Task<Result> PostAsync(string collectionName, object item)
+        {
+            if (item == null)
+                throw new ArgumentNullException("item", "item cannot be null");
+
+            var json = JsonConvert.SerializeObject(item);
+            return await PostAsync(collectionName, json);
+        }
+
+        public async Task<Result> PostAsync(string collectionName, string item)
+        {
+            if (string.IsNullOrEmpty(collectionName))
+                throw new ArgumentNullException("collectionName", "collectionName cannot be null or empty");
+
+            if (string.IsNullOrEmpty(item))
+                throw new ArgumentNullException("item", "item cannot be empty");
+
+            var url = UrlBase + collectionName;
+            var baseResult = await Communication.CallWebRequestAsync(_apiKey, url, "POST", item);
+
+            var key = baseResult.Location.Remove(0, 15).Remove(16);
 
             return new Result
             {

--- a/Orchestrate.Net/Orchestrate.cs
+++ b/Orchestrate.Net/Orchestrate.cs
@@ -136,7 +136,7 @@ namespace Orchestrate.Net
             var url = UrlBase + collectionName;
             var baseResult = Communication.CallWebRequest(_apiKey, url, "POST", item);
 
-            var key = baseResult.Location.Remove(0, 15).Remove(16);
+            var key = ExtractKeyFromLocation(baseResult.Location);
 
             return new Result
             {
@@ -651,7 +651,7 @@ namespace Orchestrate.Net
             var url = UrlBase + collectionName;
             var baseResult = await Communication.CallWebRequestAsync(_apiKey, url, "POST", item);
 
-            var key = baseResult.Location.Remove(0, 15).Remove(16);
+            var key = ExtractKeyFromLocation(baseResult.Location);
 
             return new Result
             {
@@ -1040,6 +1040,11 @@ namespace Orchestrate.Net
             var origin = new DateTime(1970, 1, 1, 0, 0, 0, 0);
             TimeSpan diff = date.ToUniversalTime() - origin;
             return Math.Floor(diff.TotalMilliseconds);
+        }
+
+        private static string ExtractKeyFromLocation(string location)
+        {
+            return location.Remove(0, 12).Remove(16);
         }
 
         #endregion

--- a/Orchestrate.Net/Orchestrate.cs
+++ b/Orchestrate.Net/Orchestrate.cs
@@ -137,7 +137,7 @@ namespace Orchestrate.Net
             var url = UrlBase + collectionName;
             var baseResult = Communication.CallWebRequest(_apiKey, url, "POST", item);
 
-            var key = ExtractKeyFromLocation(baseResult.Location);
+            var key = ExtractKeyFromLocation(baseResult, collectionName);
 
             return new Result
             {
@@ -652,7 +652,7 @@ namespace Orchestrate.Net
             var url = UrlBase + collectionName;
             var baseResult = await Communication.CallWebRequestAsync(_apiKey, url, "POST", item);
 
-            var key = ExtractKeyFromLocation(baseResult.Location);
+            var key = ExtractKeyFromLocation(baseResult, collectionName);
 
             return new Result
             {
@@ -1043,9 +1043,13 @@ namespace Orchestrate.Net
             return Math.Floor(diff.TotalMilliseconds);
         }
 
-        private static string ExtractKeyFromLocation(string location)
+        private static string ExtractKeyFromLocation(BaseResult baseResult, string collection)
         {
-            return location.Remove(0, 12).Remove(16);
+            // Always in the format /v0/<collection>/<key>/refs/<ref>
+            // <ref> is included in BaseResult
+            string key = baseResult.Location.Replace("/v0/" +  collection + "/", "");
+            int index = key.IndexOf("/refs");
+            return key.Remove(index);
         }
 
         #endregion


### PR DESCRIPTION
I've added the functionality for the POST method [described here](https://orchestrate.io/docs/apiref#keyvalue). I've also added Tests for the new functionality, all of which are passing on my end.

I've also added an optional parameter to the constructor which allows for usage of the different datacentres offered by Orchestrate.

Hope the changes are all good, I couldn't see anywhere where this was already implemented and I tried to be as consistent as possible with the rest of the code base.
